### PR TITLE
Documented the use of `flutter pub add` and `flutter pub remove`

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -271,6 +271,7 @@
       { "source": "/go/go-router-v3-breaking-changes", "destination": "https://docs.google.com/document/d/1TZ8G_TZ6Dqcpz64qXxArGhtHKFECDEPZFEuxYwQjJz4/edit#", "type": 301 },
       { "source": "/go/go-router-v4-breaking-changes", "destination": "https://docs.google.com/document/d/1T2LmzMj5HpD7hEexXL4Xz6vqoJD81bEGaa9NsV24faw/edit?usp=sharing&resourcekey=0-PuQbtDVl7ZabpJ2B9AHWUg", "type": 301 },
       { "source": "/go/go-router-v5-breaking-changes", "destination": "https://docs.google.com/document/d/10l22o4ml4Ss83UyzqUC8_xYOv_QjZEi80lJDNE4q7wM/edit?pli=1&resourcekey=0-U-BXBQzNfkk4v241Ow-vZg", "type": 301 },
+      { "source": "/go/go-router-v5-1-2-breaking-changes", "destination": "https://docs.google.com/document/d/1HMUZA-lgeGFZ5JyU4g5jOFhbYAbk9ysfz9Ok1tGvqRw/edit?resourcekey=0-7otvjyBeefkQ9xQP9S2-9w#", "type": 301 },
       { "source": "/go/handling-synchronous-keyboard-events", "destination": "https://docs.google.com/document/d/1rWXSjkb2ZKv-cpg26lVK0aZi4cVeXJ8j7YmSJdq2TOM/edit", "type": 301 },
       { "source": "/go/hot-ui-early-prototype-demos", "destination": "https://docs.google.com/document/d/1ZaHqKnON8-WEhke3Y6FpHeuB5BNlxDQj1cCYB1SoI_g", "type": 301 },
       { "source": "/go/i18n-user-guide", "destination": "https://docs.google.com/document/d/10e0saTfAv32OZLRmONy866vnaw0I2jwL8zukykpgWBc/edit", "type": 301 },

--- a/src/development/packages-and-plugins/using-packages.md
+++ b/src/development/packages-and-plugins/using-packages.md
@@ -102,6 +102,31 @@ To add the package, `css_colors`, to an app:
      Hot reload and hot restart only update the Dart code,
      so a full restart of the app might be required to avoid
      errors like `MissingPluginException` when using the package.
+     
+### Adding a package dependency to an app using `flutter pub add`
+
+To add the package, `css_colors`, to an app:
+
+1. Issue the command while being inside the project directory
+   * `flutter pub add css_colors`
+
+1. Import it
+   * Add a corresponding `import` statement in the Dart code.
+
+1. Stop and restart the app, if necessary
+   * If the package brings platform-specific code
+     (Kotlin/Java for Android, Swift/Objective-C for iOS),
+     that code must be built into your app.
+     Hot reload and hot restart only update the Dart code,
+     so a full restart of the app might be required to avoid
+     errors like `MissingPluginException` when using the package.
+     
+### Removing a package dependency to an app using `flutter pub remove`
+
+To remove the package, `css_colors`, to an app:
+
+1. Issue the command while being inside the project directory
+   * `flutter pub remove css_colors`
 
 The [Installing tab][],
 available on any package page on pub.dev,


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
There was no mention of `flutter pub add` and `flutter pub remove` to work with flutter packages. Added these in the documentation.

_Issues fixed by this PR (if any):_ Fixes #7654

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
